### PR TITLE
fix/room access action

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,11 +7,11 @@
 const { version: platformVersion } = require("zapier-platform-core")
 const { beforeSessionAuthRequest, sessionAuth } = require("./auth.js")
 const {
-  accessRoom,
   archiveRoom,
   createFile,
   createFileInMyDocuments,
   createFolder,
+  externalLink,
   fileCreated,
   folderCreated,
   roomArchived,
@@ -36,11 +36,11 @@ const App = {
     [userAdded.key]: userAdded
   },
   creates: {
-    [accessRoom.key]: accessRoom,
     [archiveRoom.key]: archiveRoom,
     [createFile.key]: createFile,
     [createFileInMyDocuments.key]: createFileInMyDocuments,
     [createFolder.key]: createFolder,
+    [externalLink.key]: externalLink,
     [roomCreate.key]: roomCreate
   }
 }

--- a/app/app.test.js
+++ b/app/app.test.js
@@ -11,11 +11,11 @@ const { test } = require("uvu")
 const { App } = require("./app.js")
 const { beforeSessionAuthRequest, sessionAuth } = require("./auth.js")
 const {
-  accessRoom,
   archiveRoom,
   createFile,
   createFileInMyDocuments,
   createFolder,
+  externalLink,
   fileCreated,
   folderCreated,
   roomArchived,
@@ -76,11 +76,6 @@ test("has the `userAdded` trigger", () => {
 })
 
 // Actions
-test("has the `accessRoom` creation", () => {
-  const has = App.creates[accessRoom.key] === accessRoom
-  equal(has, true)
-})
-
 test("has the `archiveRoom` creation", () => {
   const has = App.creates[archiveRoom.key] === archiveRoom
   equal(has, true)
@@ -98,6 +93,11 @@ test("has the `createFileInMyDocuments` creation", () => {
 
 test("has the `createFolder` creation", () => {
   const has = App.creates[createFolder.key] === createFolder
+  equal(has, true)
+})
+
+test("has the `externalLink` creation", () => {
+  const has = App.creates[externalLink.key] === externalLink
   equal(has, true)
 })
 

--- a/app/files.js
+++ b/app/files.js
@@ -251,36 +251,6 @@ const roomArchived = {
 }
 
 // Actions
-const accessRoom = {
-  key: "accessRoom",
-  noun: "Room",
-  display: {
-    label: "Access Room",
-    description: "Returns the links of a room."
-  },
-  operation: {
-    inputFields: [
-      {
-        label: "id",
-        key: "folderId",
-        required: true,
-        dynamic: "roomCreated.id.folderId"
-      }
-    ],
-    /**
-     * @param {ZObject} z
-     * @param {Bundle<SessionAuthenticationData, RoomOptions>} bundle
-     * @returns {Promise<Link>}
-     */
-    async perform(z, bundle) {
-      const client = new Client(bundle.authData.baseUrl, z.request)
-      const files = new FilesService(client)
-      return await files.accessRoom(bundle.inputData)
-    },
-    sample: samples.link
-  }
-}
-
 const archiveRoom = {
   key: "archiveRoom",
   noun: "Room",
@@ -414,6 +384,36 @@ const createFolder = {
   }
 }
 
+const externalLink = {
+  key: "externalLink",
+  noun: "Room",
+  display: {
+    label: "External Link",
+    description: "Returns the primary external link of a room."
+  },
+  operation: {
+    inputFields: [
+      {
+        label: "id",
+        key: "folderId",
+        required: true,
+        dynamic: "roomCreated.id.folderId"
+      }
+    ],
+    /**
+     * @param {ZObject} z
+     * @param {Bundle<SessionAuthenticationData, RoomOptions>} bundle
+     * @returns {Promise<Link>}
+     */
+    async perform(z, bundle) {
+      const client = new Client(bundle.authData.baseUrl, z.request)
+      const files = new FilesService(client)
+      return await files.externalLink(bundle.inputData)
+    },
+    sample: samples.link
+  }
+}
+
 const roomCreate = {
   key: "roomCreate",
   noun: "Rooms",
@@ -452,18 +452,6 @@ const roomCreate = {
 }
 
 class FilesService extends Service {
-  /**
-   * ```http
-   * GET api/2.0/files/rooms/{{id}}/links
-   * ```
-   * @param {RoomOptions} data
-   * @returns {Promise<Link>}
-   */
-  accessRoom(data) {
-    const url = this.client.url(`/files/rooms/${data.id}/link`)
-    return this.client.request("GET", url)
-  }
-
   /**
    * ```http
    * PUT /files/rooms
@@ -526,6 +514,18 @@ class FilesService extends Service {
 
   /**
    * ```http
+   * GET /files/rooms/{{id}}/link
+   * ```
+   * @param {RoomOptions} data
+   * @returns {Promise<Link>}
+   */
+  externalLink(data) {
+    const url = this.client.url(`/files/rooms/${data.id}/link`)
+    return this.client.request("GET", url)
+  }
+
+  /**
+   * ```http
    * GET /files/{{folderId}}
    * ```
    * @param {number} folderId
@@ -564,11 +564,11 @@ class FilesService extends Service {
 }
 
 module.exports = {
-  accessRoom,
   archiveRoom,
   createFile,
   createFileInMyDocuments,
   createFolder,
+  externalLink,
   fileCreated,
   folderCreated,
   roomArchived,

--- a/app/files.js
+++ b/app/files.js
@@ -275,8 +275,7 @@ const accessRoom = {
     async perform(z, bundle) {
       const client = new Client(bundle.authData.baseUrl, z.request)
       const files = new FilesService(client)
-      const link = await files.accessRoom(bundle.inputData)
-      return link[0]
+      return await files.accessRoom(bundle.inputData)
     },
     sample: samples.link
   }
@@ -458,10 +457,10 @@ class FilesService extends Service {
    * GET api/2.0/files/rooms/{{id}}/links
    * ```
    * @param {RoomOptions} data
-   * @returns {Promise<Link[]>}
+   * @returns {Promise<Link>}
    */
   accessRoom(data) {
-    const url = this.client.url(`/files/rooms/${data.id}/links`)
+    const url = this.client.url(`/files/rooms/${data.id}/link`)
     return this.client.request("GET", url)
   }
 

--- a/app/files.test.js
+++ b/app/files.test.js
@@ -10,11 +10,11 @@ const { createAppTester } = require("zapier-platform-core")
 const { App } = require("./app.js")
 const { sessionAuthContext, sessionAuthPerform } = require("./auth.fixture.js")
 const {
-  accessRoom,
   archiveRoom,
   createFile,
   createFileInMyDocuments,
   createFolder,
+  externalLink,
   fileCreated,
   folderCreated,
   roomArchived,
@@ -113,8 +113,8 @@ Files("create a folder", async (context) => {
   not.equal(result.id, 0)
 })
 
-Files("returns the links of a room", async (context) => {
-  const { perform } = accessRoom.operation
+Files("returns the link of a room", async (context) => {
+  const { perform } = externalLink.operation
   /** @type {RoomOptions} */
   const inputData = {
     id: context.inputData.folderId,

--- a/app/files.test.js
+++ b/app/files.test.js
@@ -98,7 +98,7 @@ Files("returns the links of a room", async (context) => {
   const { perform } = accessRoom.operation
   /** @type {RoomOptions} */
   const inputData = {
-    id: 25579,
+    id: context.inputData.folderId,
     title: "TODO"
   }
   const bundle = {

--- a/app/files.test.js
+++ b/app/files.test.js
@@ -35,6 +35,25 @@ Files.before(async (context) => {
   await sessionAuthPerform(tester, context)
 })
 
+Files("create a room", async (context) => {
+  const { perform } = roomCreate.operation
+  /** @type {RoomOptions} */
+  const inputData = {
+    title: "Test room",
+    type: "CustomRoom"
+  }
+  const bundle = {
+    authData: context.authData,
+    inputData
+  }
+  const room = await tester(perform, bundle)
+  if (!room) {
+    unreachable("TODO")
+    return
+  }
+  equal(bundle.inputData.title, room.title)
+})
+
 Files("triggers when a room is created", async (context) => {
   const { perform } = roomCreated.operation
   const bundle = {
@@ -109,40 +128,6 @@ Files("returns the links of a room", async (context) => {
   not.equal(result.sharedTo.shareLink, null)
 })
 
-Files("archive the room", async (context) => {
-  const { perform } = archiveRoom.operation
-  /** @type {RoomOptions} */
-  const inputData = {
-    id: context.inputData.folderId,
-    title: "TODO"
-  }
-  const bundle = {
-    authData: context.authData,
-    inputData
-  }
-  const result = await tester(perform, bundle)
-  equal(result.finished, true)
-})
-
-Files("create a room", async (context) => {
-  const { perform } = roomCreate.operation
-  /** @type {RoomOptions} */
-  const inputData = {
-    title: "Test room",
-    type: "CustomRoom"
-  }
-  const bundle = {
-    authData: context.authData,
-    inputData
-  }
-  const room = await tester(perform, bundle)
-  if (!room) {
-    unreachable("TODO")
-    return
-  }
-  equal(bundle.inputData.title, room.title)
-})
-
 Files("triggers when a folder is created", async (context) => {
   const { perform } = folderCreated.operation
   const inputData = {
@@ -180,6 +165,21 @@ Files("triggers when a file is created", async (context) => {
   }
 
   not.equal(newFile.id, 0)
+})
+
+Files("archive the room", async (context) => {
+  const { perform } = archiveRoom.operation
+  /** @type {RoomOptions} */
+  const inputData = {
+    id: context.inputData.folderId,
+    title: "TODO"
+  }
+  const bundle = {
+    authData: context.authData,
+    inputData
+  }
+  const result = await tester(perform, bundle)
+  equal(result.finished, true)
 })
 
 Files("triggers when a room is archived", async (context) => {


### PR DESCRIPTION
The `api/2.0/files/rooms/{{id}}/links` endpoint has been replaced to `api/2.0/files/rooms/{{id}}/link`. `link` returns a general link, while `links` is a list of already generated links. `links` will return an empty array if no shared link has been generated before.

The order of tests has been changed to avoid situations where a room is archived and then queried in subsequent tests.