### PR TITLE
rename jobs in actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  audit:
+  release:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  audit:
+  stage:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
My fault. When I copied the action files, I forgot to rename their jobs.