### PR TITLE
fix: security vulnerability with z.request() and z.stashFile()

### DIFF
--- a/app/zapier/files/hydrators.js
+++ b/app/zapier/files/hydrators.js
@@ -18,6 +18,7 @@
 const stashFile = async (z, bundle) => {
   const filePromise = z.request({
     raw: true,
+    redirect: "error",
     url: bundle.inputData.url
   })
   return z.stashFile(filePromise)

--- a/app/zapier/files/uploader.js
+++ b/app/zapier/files/uploader.js
@@ -63,7 +63,11 @@ class Uploader {
     if (url.startsWith("https://zapier")) {
       zapierUrl = url
     } else {
-      const filePromise = this.z.request({ raw: true, url })
+      const filePromise = this.z.request({
+        raw: true,
+        redirect: "error",
+        url
+      })
       zapierUrl = await this.z.stashFile(filePromise)
     }
     return zapierUrl


### PR DESCRIPTION
Added `redirect: 'error'` to any `z.request()` calls that are followed by `z.stashFile()`. This change will prevent potential exploitation of vulnerability SECVULN-96.