### PR TITLE
fix: add a remote user filter for the user list

### DIFF
--- a/app/docspace/client/client.js
+++ b/app/docspace/client/client.js
@@ -24,6 +24,7 @@
 
 const ACTIVATION_STATUS = 1
 const ONLY_USERS_FILTER_TYPE = 0
+const REMOVED_USER_ID = "4A515A15-D4D6-4b8e-828E-E0586F18F3A3"
 
 /**
  * @param {number} type
@@ -218,6 +219,7 @@ module.exports = {
   Client,
   ONLY_USERS_FILTER_TYPE,
   Progress,
+  REMOVED_USER_ID,
   Service,
   basicFormRoomRoles,
   collaborationRoomRoles,

--- a/app/zapier/files/triggers.js
+++ b/app/zapier/files/triggers.js
@@ -13,7 +13,8 @@ const {
   isBasicFormRoom,
   isCollaborationRoom,
   isCustomRoom,
-  ONLY_USERS_FILTER_TYPE
+  ONLY_USERS_FILTER_TYPE,
+  REMOVED_USER_ID
 } = require("../../docspace/client/client.js")
 const { FilesService } = require("../../docspace/files/files.js")
 const samples = require("../../docspace/files/files.samples.js")
@@ -705,6 +706,7 @@ const userInvited = {
         filterType: ONLY_USERS_FILTER_TYPE
       }
       let users = await files.listUsers(bundle.inputData.id, filters)
+      users = users.filter((item) => item.sharedTo.id !== REMOVED_USER_ID)
       if (bundle.inputData.active) {
         users = users.filter((item) => item.sharedTo.activationStatus === ACTIVATION_STATUS)
       }

--- a/app/zapier/people/actions.js
+++ b/app/zapier/people/actions.js
@@ -4,7 +4,7 @@
 
 // @ts-check
 
-const { Client } = require("../../docspace/client/client.js")
+const { Client, REMOVED_USER_ID } = require("../../docspace/client/client.js")
 const { PeopleService } = require("../../docspace/people/people.js")
 const samples = require("../../docspace/people/people.samples.js")
 
@@ -65,8 +65,9 @@ const inviteUser = {
       }
       const client = new Client(bundle.authData.baseUrl, z.request)
       const people = new PeopleService(client)
-      const userList = await people.listUsers()
-      let invitedUser = findUser(bundle.inputData.email, userList)
+      let users = await people.listUsers()
+      users = users.filter((item) => item.id !== REMOVED_USER_ID)
+      let invitedUser = findUser(bundle.inputData.email, users)
       if (invitedUser) {
         return invitedUser
       }

--- a/app/zapier/people/triggers.js
+++ b/app/zapier/people/triggers.js
@@ -4,7 +4,7 @@
 
 // @ts-check
 
-const { Client } = require("../../docspace/client/client.js")
+const { Client, REMOVED_USER_ID } = require("../../docspace/client/client.js")
 const { PeopleService } = require("../../docspace/people/people.js")
 const samples = require("../../docspace/people/people.samples.js")
 
@@ -29,7 +29,9 @@ const userAdded = {
     async perform(z, bundle) {
       const client = new Client(bundle.authData.baseUrl, z.request)
       const people = new PeopleService(client)
-      return await people.listUsers()
+      var users = await people.listUsers()
+      users = users.filter((item) => item.id !== REMOVED_USER_ID)
+      return users
     },
     sample: samples.user
   }


### PR DESCRIPTION
The remote user ID is always the same. If there are several users deleted from DocSpace in the user array, zapier will return an error related to the uniqueness of the id of each element.