### PR TITLE
fix: check finished status

### DIFF
--- a/app/docspace/client/client.js
+++ b/app/docspace/client/client.js
@@ -178,7 +178,7 @@ class Progress {
         }
 
         if (Object.hasOwn(progress, "progress")) {
-          if (progress.progress === 100) {
+          if (progress.progress === 100 && progress.finished) {
             return progress
           }
         }

--- a/app/docspace/client/client.test.js
+++ b/app/docspace/client/client.test.js
@@ -154,13 +154,17 @@ test("progress breaks if the response contains an error", async () => {
 test("progress completes when the response contains 100 progress", async () => {
   let i = 0
   let p = 0
+  let finished = false
   async function endpoint() {
     i += 1
     p += 50
+    if (p === 100) {
+      finished = true
+    }
     return [
       {
         error: "",
-        finished: false,
+        finished: finished,
         id: "00000000-1111-2222-3333-444444444444",
         operation: 0,
         percents: 0,
@@ -175,6 +179,7 @@ test("progress completes when the response contains 100 progress", async () => {
 
   equal(i, 2)
   equal(p, 100)
+  equal(finished, true)
   equal(response.error, "")
   equal(response.progress, 100)
 })


### PR DESCRIPTION
[fileops ](https://api.onlyoffice.com/docspace/method/files/get/api/2.0/files/fileops) returns an array of current operations and their status, sometimes, `Progress` completion percentage is 100, but `Finished` is `false`.
With the next iteration, when the status of operations is queried again, `Finished` is `true`.
Added check for `Finished` status